### PR TITLE
Correctly combine color channels in 16bpp mode.

### DIFF
--- a/renderer/FPGARenderer/FPGARendererFTDI.cpp
+++ b/renderer/FPGARenderer/FPGARendererFTDI.cpp
@@ -119,7 +119,7 @@ void FPGARendererFTDI::render() {
                 }
                 if(bitDepthInBytes == 2){
                     uint16_t *pixelP = (uint16_t *)(cmd_buf + i + screen->getOffsetX() * (llen / screenCount) + x * bitDepthInBytes);
-                    *pixelP = (tmpColor.r() | tmpColor.g()<<6 | tmpColor.b()<<11) & 0xFFFF;
+                    *pixelP = tmpColor.r() >> 3 << 11 | tmpColor.g() >> 2 << 6 | tmpColor.b() >> 3;
                 }else if(bitDepthInBytes == 3){
                     cmd_buf[i + screen->getOffsetX() * (llen / screenCount) + x * bitDepthInBytes] = tmpColor.r();
                     cmd_buf[i + screen->getOffsetX() * (llen / screenCount) + x * bitDepthInBytes + 1] = tmpColor.g();


### PR DESCRIPTION
(a) color order was backward -- it was big-endian BGR instead of big-endian RGB.
(b) low order bits of colors needed to be removed so they don't turn on bits in adjacent
color channel.

This change fixes both.